### PR TITLE
feat: allow generation running on subset of workers

### DIFF
--- a/examples/qwen2.5-7B-rlvr_megatron/gen_config_4gpu.yaml
+++ b/examples/qwen2.5-7B-rlvr_megatron/gen_config_4gpu.yaml
@@ -38,6 +38,9 @@ logging_steps: 1
 eval_steps: 1
 resume_from_checkpoint: false
 
+# alive check should be frequent when migration is enabled.
+alive_check_interval: 1
+
 # prompt
 rollout_batch_size: 128
 prompt_length: 2048

--- a/roll/distributed/scheduler/generate_scheduler.py
+++ b/roll/distributed/scheduler/generate_scheduler.py
@@ -355,7 +355,6 @@ class DynamicSamplingScheduler:
         self.request_id_2_dp_rank = {}
         self.requests_buffers: Dict[str, DataProto] = {}
         self.lock = threading.Lock()
-        self.last_alive_check = time.time()
         self.dataset_iter_count = 0
         self.exception_queue = queue.Queue()
         self.running = False
@@ -367,6 +366,9 @@ class DynamicSamplingScheduler:
         self.max_additional_running_prompts = self.pipeline_config.max_additional_running_prompts
         self.is_use_additional_prompts = self.pipeline_config.is_use_additional_prompts
         self.alive_check_interval = self.pipeline_config.alive_check_interval
+
+        # HACK: We need to check alive at the beginning to get correct initial DP workers.
+        self.last_alive_check = time.time() - self.alive_check_interval
 
         self.actor_cluster = None
         self.reward_clusters = None
@@ -503,6 +505,7 @@ class DynamicSamplingScheduler:
         request_id_2_request = {}
         migration_scheduler: MigrationSchedulerBase = NaiveMigrationScheduler()
         get_worker_stat_fns = [self.actor_cluster.workers[i].get_stats for i in range(len(self.actor_cluster.workers))]
+        ready_workers = []
         while True:
             if (
                 sum([len(v) for v in list(self.completed_buffers.values())[:]])
@@ -510,7 +513,17 @@ class DynamicSamplingScheduler:
             ):
                 self.running = False
                 break
-            self.check_worker_alive(self.actor_cluster)
+            worker_status = self.check_worker_alive(self.actor_cluster)
+            # For skipped iterations, worker_status will be [] due to no checks are performed.
+            # For non-skip iterations, we update ready_workers based on the new worker_status.
+            if len(worker_status) != 0:
+                print(f"=== alive check: {worker_status}")
+                ready_workers = [i for i in range(len(worker_status)) if worker_status[i] == 'ready']
+            if len(ready_workers) == 0:
+                print(f"*** No available workers, current status: {worker_status}")
+                time.sleep(1)
+                continue
+
             self.check_response_callback()
 
             # Madoka: the request migration logic based on re-calculation
@@ -625,7 +638,9 @@ class DynamicSamplingScheduler:
                 mig_end_t = time.time()
                 print(f"==== migrate {sum([len(i) for i in migrate_src_dst.values()])} requests ({len(reqs_to_migrate)} responses), costs {mig_end_t - mig_start_t}s.")
 
-            if not self.check_send_new_request():
+            # Besides no new requests, we should also skip this iteration if all dp ranks are full.
+            dp_rank = self.get_available_dp_rank_no_wait(ready_workers)
+            if dp_rank is None or (not self.check_send_new_request()):
                 time.sleep(1)
                 continue
 
@@ -638,7 +653,7 @@ class DynamicSamplingScheduler:
             # replica, redundancy
             request_data_list = self.expand_requests(request_data)
 
-            dp_rank = next(self.get_available_dp_rank())
+            # dp_rank = next(self.get_available_dp_rank())
             with self.lock:
                 self.prompt_use_count += 1
                 self.running_prompts += 1
@@ -657,6 +672,7 @@ class DynamicSamplingScheduler:
                             command=GenerateRequestType.ADD, data=req
                         )
                     )
+                    print(f"=== add request {request_id} to worker-{dp_rank}, t={time.time()}")
                     req.meta_info.pop("response_callback_fn")
                     self.load_balance_coordinator[dp_rank] += 1
                     self.dp_fetch_count[dp_rank] += 1
@@ -859,9 +875,12 @@ class DynamicSamplingScheduler:
     def check_worker_alive(self, cluster):
         # 探测dp worker是否存活，dp worker的server thread可能由于异常退出，造成hang
         current_time = time.time()
+        alive_status = []
         if current_time - self.last_alive_check >= self.alive_check_interval:
-            cluster.add_request(command=GenerateRequestType.ALIVE_CHECK, data=DataProto())
+            worker_info = cluster.add_request(command=GenerateRequestType.ALIVE_CHECK, data=DataProto())
             self.last_alive_check = current_time
+            alive_status = [w.meta_info["status"] for w in worker_info]
+        return alive_status
 
     def check_response_callback(self):
         if self.exception_queue.qsize() > 0:
@@ -884,6 +903,16 @@ class DynamicSamplingScheduler:
             )
             if self.load_balance_coordinator[sorted_ranks[0]] < self.max_running_requests:
                 yield sorted_ranks[0]
+
+    def get_available_dp_rank_no_wait(self, ready_workers):
+        # 负载均衡逻辑，期望各dp 正在处理的条数基本接近
+        sorted_ranks = sorted(
+            self.load_balance_coordinator.keys(), key=lambda rank: (self.load_balance_coordinator[rank], rank)
+        )
+        for rank in sorted_ranks:
+            if (rank in ready_workers) and (self.load_balance_coordinator[rank] < self.max_running_requests):
+                return rank
+        return None
 
 
 @ray.remote

--- a/roll/distributed/strategy/vllm_strategy.py
+++ b/roll/distributed/strategy/vllm_strategy.py
@@ -158,25 +158,27 @@ class VllmStrategy(InferenceStrategy):
         return output
 
     def process_vllm_output(self, vllm_outputs: List[RequestOutput], request_complete_callback):
-        # TODO: Lunxi: Assume num_return_sequences > 1.
+        # We use the request id format to distinguish migrated responses and normal requests.
+        # Request id of a migrated response is like f"{req_id}_{resp_id}_{num_seqs}".
         shard_storage_pipeline = self.shared_storage.pipeline()
         migrated_resps: List[RequestOutput] = []
         normal_reqs: List[RequestOutput] = []
         for output_request in vllm_outputs:
-            if len(output_request.outputs) == 1:
+            if "_" in output_request.request_id:
+                assert len(output_request.request_id.split("_")) == 3
+                assert len(output_request.outputs) == 1, "Migrated response should have only one output."
                 migrated_resps.append(output_request)
             else:
                 normal_reqs.append(output_request)
         # print(f"=== normal reqs: {[req.request_id for req in normal_reqs]} migrated resps: {[resp.request_id for resp in migrated_resps]}")
 
         # Deal with migrated responses.
-        # For a request that have only one response, which means it's a migrated response of its original request,
-        # do not process it, check if its original request has been finished instead.
+        # For a migrated response, do not process it, check if its original request has been finished instead.
         # If so, collect responses and then process the original request, else cache it in shared storage.
         origin_req_id_2_num_seqs = {}
         origin_req_id_2_resps = {}
         for migrated_resp in migrated_resps:
-            # migrated_request id is like f"{req_id}_{resp_id}_{num_seqs}"
+            # Request id of a migrated response is like f"{req_id}_{resp_id}_{num_seqs}".
             origin_req_id, resp_id, num_seqs, = migrated_resp.request_id.split("_")
 
             if origin_req_id not in origin_req_id_2_num_seqs:
@@ -225,8 +227,6 @@ class VllmStrategy(InferenceStrategy):
 
         # 转成response id, request_complete_callback
         # Deal with normal requests.
-        # Do not process requests that have only one response here, which means they are migrated responses.
-        # Instead, process normal requests that have multiple responses and are not migrated.
         normal_req_ids = [req.request_id for req in normal_reqs]
         normal_req_ids_set = set(normal_req_ids)
         # TODO: Lunxi: For duplicate requests returned by engine, just ignore them temporarily.

--- a/roll/distributed/strategy/vllm_strategy.py
+++ b/roll/distributed/strategy/vllm_strategy.py
@@ -3,6 +3,7 @@ import gc
 import os
 import itertools
 import redis
+import time
 import array
 import queue
 from concurrent import futures
@@ -47,6 +48,7 @@ class VllmStrategy(InferenceStrategy):
         self.req_id_2_resp_start_idx = {}
         self.group_name = "vllm_worker_default"
         self.running = False
+        self.ready = False
 
     def initialize(self, model_provider):
         set_seed(seed=self.worker.pipeline_config.seed)
@@ -250,9 +252,25 @@ class VllmStrategy(InferenceStrategy):
             request_complete_callback(data=output_data)
         assert len(normal_req_ids_set) == 0
 
-    def start_server(self, data: DataProto, request_complete_callback):
-        collective.barrier(group_name=self.group_name)
+    def start_server(self, data: DataProto, request_complete_callback, offload_manager):
+        # collective.barrier(group_name=self.group_name)
         self.running = True
+        self.ready = False
+
+        # Block start_server execution here, wait for a running signal from the shared storage
+        if self.shared_storage is not None:
+            while True:
+                status_bytes = self.shared_storage.get(self.worker.worker_name + "_status")
+                if status_bytes is not None:
+                    status_str = status_bytes.decode()
+                    if status_str == 'running':
+                        print("=== Got running signal!")
+                        break
+                time.sleep(0.1)
+        # Enter the offload manager, GPU memory will be allocated after here.
+        offload_manager.__enter__()
+        self.ready = True
+
         while True:
             while not self.command_queue.empty():
                 command, batch = self.command_queue.get_nowait()

--- a/roll/pipeline/base_worker.py
+++ b/roll/pipeline/base_worker.py
@@ -184,9 +184,10 @@ class ActorWorker(Worker):
             is_offload_states=is_offload_states,
             load_kwargs={"include": [OffloadStateType.model_params]},
         )
-        self.offload_manager.__enter__()
+        # self.offload_manager.__enter__()
+        # Madoka: enter the offload_manager to allocate CUDA memory when the strategy actually starts.
         self.thread_server = threading.Thread(
-            target=self.strategy.start_server, kwargs=dict(data=data, request_complete_callback=self.request_complete)
+            target=self.strategy.start_server, kwargs=dict(data=data, request_complete_callback=self.request_complete, offload_manager=self.offload_manager)
         )
         self.thread_server.start()
         while not self.strategy.running:
@@ -360,10 +361,13 @@ class ActorWorker(Worker):
         generation_config, 按request设置
         """
         if command == GenerateRequestType.ALIVE_CHECK:
+            status = "unknown"
             if self.thread_server is not None:
                 if not self.thread_server.is_alive():
                     raise Exception("thread server has stopped unexpectedly. check stderr for more info.")
-            output = DataProto(meta_info={"request_counts": len(self.response_call_back_fns)})
+                else:
+                    status = "ready" if self.strategy.ready else "waiting"
+            output = DataProto(meta_info={"request_counts": len(self.response_call_back_fns), "status": status})
             return output
         elif command == GenerateRequestType.ADD:
             assert "response_callback_fn" in data.meta_info, "response_callback_fn is not in data.meta_info"

--- a/roll/pipeline/rlvr/rlvr_config.py
+++ b/roll/pipeline/rlvr/rlvr_config.py
@@ -272,6 +272,10 @@ class RLVRConfig(BaseConfig):
             self.tag_2_domain = {
                 tag: key for key, worker_config in self.rewards.items() for tag in worker_config.tag_included
             }
+        # Madoka: the max_running_requests should match the vLLM's max_num_seqs, otherwise queuing will happen.
+        if self.actor_infer.strategy_args.strategy_name == 'vllm':
+            max_num_seqs = int(self.actor_infer.strategy_args.strategy_config.get("max_num_seqs", "256"))
+            self.max_running_requests = max_num_seqs // self.num_return_sequences_in_group
 
     def set_max_steps(self, max_steps: int):
         actor_backward_batch_size = (


### PR DESCRIPTION
Enable running generation on a subset of workers. The workers are waked up by a signal in the shared storage (is there exists one). Now, alive_check() returns the workers' status (unknown, waiting, or running) instead of running responses. 