### PR TITLE
feat: integrate train to scheduler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,6 @@ log
 roll/multi_tenant/feijiu/
 experiments/figures/
 experiments/lunxi_logs
+experiments/
+slurm-*
+run_sbatch.sh

--- a/examples/qwen2.5-7B-rlvr_megatron/new_rlvr_config_4gpu.yaml
+++ b/examples/qwen2.5-7B-rlvr_megatron/new_rlvr_config_4gpu.yaml
@@ -40,7 +40,7 @@ eval_steps: 10
 resume_from_checkpoint: false
 
 
-rollout_batch_size: 64  # prompt
+rollout_batch_size: 32  # prompt
 prompt_length: 2048
 response_length: 4096
 
@@ -123,7 +123,7 @@ actor_train:
   strategy_args:
     strategy_name: deepspeed_train
     strategy_config: ${deepspeed_zero2}
-  device_mapping: list(range(0,4))
+  device_mapping: list(range(0,2))
   infer_batch_size: 4
 
 actor_infer:
@@ -146,7 +146,7 @@ actor_infer:
       gpu_memory_utilization: 0.6
       block_size: 16
       max_model_len: 8000
-  device_mapping: list(range(0,4))
+  device_mapping: list(range(2,4))
   infer_batch_size: 1
 
 reference:
@@ -160,7 +160,7 @@ reference:
   strategy_args:
     strategy_name: hf_infer
     strategy_config: ~
-  device_mapping: list(range(0,4))
+  device_mapping: list(range(0,2))
   infer_batch_size: 8
 
 rewards:

--- a/roll/distributed/scheduler/generate_scheduler.py
+++ b/roll/distributed/scheduler/generate_scheduler.py
@@ -363,10 +363,12 @@ class DynamicSamplingScheduler:
 
         # Flow control measures. max_running_requests limits the maximum number of concurrent requests for each dp.
         # max_additional_running_prompts limits the number of prompts running simultaneously to avoid excessive consumption of prompts.
+        # enable_migration indicates whether to enable request migration
         self.max_running_requests = self.pipeline_config.max_running_requests
         self.max_additional_running_prompts = self.pipeline_config.max_additional_running_prompts
         self.is_use_additional_prompts = self.pipeline_config.is_use_additional_prompts
         self.alive_check_interval = self.pipeline_config.alive_check_interval
+        self.enable_migration = self.pipeline_config.enable_migration
 
         # HACK: We need to check alive at the beginning to get correct initial DP workers.
         self.last_alive_check = time.time() - self.alive_check_interval
@@ -531,7 +533,9 @@ class DynamicSamplingScheduler:
 
             # Madoka: the request migration logic based on re-calculation
             # `migrate_src_dst`: Dict[(from, to) -> List[req_id]], note that vLLM uses strings as req_ids.
-            migrate_src_dst = migration_scheduler.migrate(get_worker_stat_fns, self.request_id_2_dp_rank)
+            migrate_src_dst = {}
+            if self.enable_migration:
+                migrate_src_dst = migration_scheduler.migrate(get_worker_stat_fns, self.request_id_2_dp_rank)
             if len(migrate_src_dst) != 0:
                 mig_start_t = time.time()
                 # Before migration, first clean all old keys.

--- a/roll/distributed/scheduler/migration_scheduler.py
+++ b/roll/distributed/scheduler/migration_scheduler.py
@@ -98,7 +98,6 @@ class StaticAggMigrationScheduler(MigrationSchedulerBase):
         static policy, assume we have several (e.g., 128) requests on N separate workers,
         We want to migrate them to dest_workers once possible. Migration only happens once.
         '''
-        return {}
         current_time = time.time()
         if current_time - self.last_check_time <= StaticAggMigrationScheduler.CHECK_INTERVAL:
             print(f"==== scheduler: skip ({current_time - self.last_check_time})")

--- a/roll/distributed/scheduler/migration_scheduler.py
+++ b/roll/distributed/scheduler/migration_scheduler.py
@@ -98,6 +98,7 @@ class StaticAggMigrationScheduler(MigrationSchedulerBase):
         static policy, assume we have several (e.g., 128) requests on N separate workers,
         We want to migrate them to dest_workers once possible. Migration only happens once.
         '''
+        return {}
         current_time = time.time()
         if current_time - self.last_check_time <= StaticAggMigrationScheduler.CHECK_INTERVAL:
             print(f"==== scheduler: skip ({current_time - self.last_check_time})")

--- a/roll/pipeline/rlvr/rlvr_config.py
+++ b/roll/pipeline/rlvr/rlvr_config.py
@@ -112,6 +112,9 @@ class RLVRConfig(BaseConfig):
     max_additional_running_prompts: int = field(
         default=16, metadata={"help": "The additional number of running prompts, beyond batch_size."}
     )
+    enable_migration: bool = field(
+        default=False, metadata={"help": "Whether to enable migration to consolidate requests."}
+    )
 
     # role related
     pretrain: str = field(

--- a/roll/pipeline/rlvr/rlvr_pipeline.py
+++ b/roll/pipeline/rlvr/rlvr_pipeline.py
@@ -348,6 +348,7 @@ class RLVRPipeline(BasePipeline):
                         metrics_mgr.add_metrics(model_update_metrics)
                         metrics_mgr.add_metric("time/step_model_update", step_model_update_timer.last)
 
+                    # TODO: this validation pass should be enabled, but should not be here, maybe move it to generate section.
                     # if self.val_dataset and global_step % self.pipeline_config.eval_steps == 0:
                     #     with Timer(name="val_step", logger=None) as val_step_timer:
                     #         val_metrics = self.val()

--- a/roll/pipeline/rlvr/rlvr_pipeline.py
+++ b/roll/pipeline/rlvr/rlvr_pipeline.py
@@ -188,18 +188,21 @@ class RLVRPipeline(BasePipeline):
         self.pipeline_config.set_max_steps(max_steps=self.pipeline_config.max_steps)
 
         self.actor_train: Any = Cluster(
+            job_name=self.job_name,
             name=self.pipeline_config.actor_train.name,
             worker_cls=self.pipeline_config.actor_train.worker_cls,
             resource_manager=self.resource_manager,
             worker_config=self.pipeline_config.actor_train,
         )
         self.actor_infer: Any = Cluster(
+            job_name=self.job_name,
             name=self.pipeline_config.actor_infer.name,
             worker_cls=self.pipeline_config.actor_infer.worker_cls,
             resource_manager=self.resource_manager,
             worker_config=self.pipeline_config.actor_infer,
         )
         self.reference: Any = Cluster(
+            job_name=self.job_name,
             name=self.pipeline_config.reference.name,
             worker_cls=self.pipeline_config.reference.worker_cls,
             resource_manager=self.resource_manager,
@@ -207,6 +210,7 @@ class RLVRPipeline(BasePipeline):
         )
         if self.pipeline_config.adv_estimator == "gae":
             self.critic: Any = Cluster(
+                job_name=self.job_name,
                 name=self.pipeline_config.critic.name,
                 worker_cls=self.pipeline_config.critic.worker_cls,
                 resource_manager=self.resource_manager,
@@ -214,6 +218,7 @@ class RLVRPipeline(BasePipeline):
             )
         self.rewards: Dict[str, Any] = {
             key: Cluster(
+                job_name=self.job_name,
                 name=f"reward-{key}",
                 worker_cls=worker_config.worker_cls,
                 resource_manager=self.resource_manager,
@@ -332,214 +337,199 @@ class RLVRPipeline(BasePipeline):
 
             metrics_mgr.clear_metrics()
             with tps_timer, Timer(name="step_total", logger=None) as step_total_timer:
+                with self.scheduler_section("update"):
+                    # 先model update，resume时不需要保存infer cluster的状态
+                    if self.pipeline_config.adv_estimator == "gae":
+                        self.critic.offload_states(blocking=True)
+                    self.actor_train.offload_states(blocking=True)
 
-                # 先model update，resume时不需要保存infer cluster的状态
-                if self.pipeline_config.adv_estimator == "gae":
-                    self.critic.offload_states(blocking=True)
-                self.actor_train.offload_states(blocking=True)
+                    with Timer(name="step_model_update", logger=None) as step_model_update_timer:
+                        model_update_metrics: Dict = self.model_update(global_step)
+                        metrics_mgr.add_metrics(model_update_metrics)
+                        metrics_mgr.add_metric("time/step_model_update", step_model_update_timer.last)
 
-                with Timer(name="step_model_update", logger=None) as step_model_update_timer:
-                    model_update_metrics: Dict = self.model_update(global_step)
-                    metrics_mgr.add_metrics(model_update_metrics)
-                    metrics_mgr.add_metric("time/step_model_update", step_model_update_timer.last)
-
-                if self.val_dataset and global_step % self.pipeline_config.eval_steps == 0:
-                    with Timer(name="val_step", logger=None) as val_step_timer:
-                        val_metrics = self.val()
-                        metrics_mgr.add_metrics(val_metrics)
-                        metrics_mgr.add_metric("time/val_step", val_step_timer.last)
-
+                    # if self.val_dataset and global_step % self.pipeline_config.eval_steps == 0:
+                    #     with Timer(name="val_step", logger=None) as val_step_timer:
+                    #         val_metrics = self.val()
+                    #         metrics_mgr.add_metrics(val_metrics)
+                    #         metrics_mgr.add_metric("time/val_step", val_step_timer.last)
                 batch: DataProto = DataProto()
                 batch.meta_info = {"global_step": global_step}
 
-                #### Wait for generation
-                if self.shared_storage is not None:
-                    self.wait_gen()
-
                 # 要按domain group by生成对应的batch
-                with actor_infer_timer, actor_infer_response_timer, Timer(
-                    name="step_generate", logger=None
-                ) as step_generate_timer:
-                    domain_batches = {}
-                    batch.meta_info["generation_config"] = self.actor_infer.worker_config.generating_args.to_dict()
-                    self.actor_infer.start_server(data=DataProto(meta_info=batch.meta_info))
-                    for reward_cluster in self.rewards.values():
-                        reward_cluster.load_states()
+                with self.scheduler_section("generate"):
+                    with actor_infer_timer, actor_infer_response_timer, Timer(
+                        name="step_generate", logger=None
+                    ) as step_generate_timer:
+                        domain_batches = {}
+                        batch.meta_info["generation_config"] = self.actor_infer.worker_config.generating_args.to_dict()
+                        self.actor_infer.start_server(data=DataProto(meta_info=batch.meta_info))
+                        for reward_cluster in self.rewards.values():
+                            reward_cluster.load_states()
 
-                    batch.meta_info["is_offload_states"] = False
-                    scheduler_refs = {}
-                    for domain, scheduler in self.generate_schedulers.items():
-                        scheduler_refs[domain] = scheduler.get_batch.remote(data=batch, batch_size=self.domain_batch_size[domain])
-                    for domain, scheduler_ref in scheduler_refs.items():
-                        domain_batch: DataProto = ray.get(scheduler_ref, timeout=self.pipeline_config.rpc_timeout)
-                        metrics_mgr.add_domain_metrics(
-                            domain, reduce_metrics(domain_batch.meta_info.pop("metrics", {}))
-                        )
-                        domain_batches[domain] = domain_batch
-                    generate_output = DataProto.concat([domain_batch for domain_batch in domain_batches.values()])
-                    generate_output.meta_info.pop("is_offload_states", None)
+                        batch.meta_info["is_offload_states"] = False
+                        scheduler_refs = {}
+                        for domain, scheduler in self.generate_schedulers.items():
+                            scheduler_refs[domain] = scheduler.get_batch.remote(data=batch, batch_size=self.domain_batch_size[domain])
+                        for domain, scheduler_ref in scheduler_refs.items():
+                            domain_batch: DataProto = ray.get(scheduler_ref, timeout=self.pipeline_config.rpc_timeout)
+                            metrics_mgr.add_domain_metrics(
+                                domain, reduce_metrics(domain_batch.meta_info.pop("metrics", {}))
+                            )
+                            domain_batches[domain] = domain_batch
+                        generate_output = DataProto.concat([domain_batch for domain_batch in domain_batches.values()])
+                        generate_output.meta_info.pop("is_offload_states", None)
 
-                    for reward_cluster in self.rewards.values():
-                        reward_cluster.offload_states()
-                    gen_metrics = self.actor_infer.stop_server()
-                metrics_mgr.add_domain_metrics(domain, reduce_metrics(gen_metrics.meta_info.pop("metrics", {})))
-                metrics_mgr.add_metric("time/step_generate", step_generate_timer.last)
+                        for reward_cluster in self.rewards.values():
+                            reward_cluster.offload_states()
+                        gen_metrics = self.actor_infer.stop_server()
+                    metrics_mgr.add_domain_metrics(domain, reduce_metrics(gen_metrics.meta_info.pop("metrics", {})))
+                    metrics_mgr.add_metric("time/step_generate", step_generate_timer.last)
 
                 batch = generate_output
 
-                #### Generation done!!
-                if self.shared_storage is not None:
-                    self.shared_storage.set("running_gen_job", "empty")
+                with self.scheduler_section("train"):
+                    with Timer(name="cal_ref_log_probs", logger=None) as cal_ref_log_probs_timer:
+                        ref_log_probs = self.reference.compute_log_probs(batch, blocking=True)
+                        metrics_mgr.add_reduced_metrics(ref_log_probs.meta_info.pop("metrics", {}))
+                        ref_log_probs.rename(old_keys="log_probs", new_keys="ref_log_probs")
+                        batch = batch.union(ref_log_probs)
+                        metrics_mgr.add_metric("time/ref_log_probs_values", cal_ref_log_probs_timer.last)
 
-                #### Wait for ref and training
-                if self.shared_storage is not None:
-                    self.wait_train()
-
-                with Timer(name="cal_ref_log_probs", logger=None) as cal_ref_log_probs_timer:
-                    ref_log_probs = self.reference.compute_log_probs(batch, blocking=True)
-                    metrics_mgr.add_reduced_metrics(ref_log_probs.meta_info.pop("metrics", {}))
-                    ref_log_probs.rename(old_keys="log_probs", new_keys="ref_log_probs")
-                    batch = batch.union(ref_log_probs)
-                    metrics_mgr.add_metric("time/ref_log_probs_values", cal_ref_log_probs_timer.last)
-
-                with Timer(name="cal_old_log_probs_values", logger=None) as cal_old_logpb_timer:
-                    batch.meta_info["is_offload_states"] = False
-                    if self.pipeline_config.adv_estimator == "gae":
-                        values_refs: List[ray.ObjectRef] = self.critic.compute_values(batch, blocking=False)
-                    old_log_probs_refs: List[ray.ObjectRef] = self.actor_train.compute_log_probs(batch, blocking=False)
-                    old_log_probs = DataProto.materialize_concat(data_refs=old_log_probs_refs)
-                    agg_entropy = agg_loss(
-                        loss_mat=old_log_probs.batch["entropy"],
-                        loss_mask=batch.batch["response_mask"][:, 1:],
-                        loss_agg_mode="token-mean",
-                    )
-                    batch.meta_info["agg_entropy"] = agg_entropy
-
-                    if self.pipeline_config.adv_estimator == "gae":
-                        values = DataProto.materialize_concat(data_refs=values_refs)
-                        batch = batch.union(values)
-                        metrics_mgr.add_reduced_metrics(values.meta_info.pop("metrics", {}))
-
-                    batch.batch["old_log_probs"] = old_log_probs.batch["log_probs"]
-                    metrics_mgr.add_reduced_metrics(old_log_probs.meta_info.pop("metrics", {}))
-                    metrics_mgr.add_metric("time/old_log_probs", cal_old_logpb_timer.last)
-
-                # 要按domain group by处理reward
-                batch.batch["prompt_id"] = torch.arange(batch.batch.batch_size[0], device=batch.batch.device)
-                batch_grouped: Dict[str, DataProto] = batch.group_by("domain")
-                batch_list = []
-                for domain, domain_batch in batch_grouped.items():
-                    # 1. 处理mask相关策略， 获取sample level mask
-                    with Timer(name="get_sample_level_mask", logger=None) as get_sample_level_mask_timer:
-                        domain_batch, mask_metrics = get_sample_level_mask(domain_batch, self.pipeline_config)
-                        metrics_mgr.add_metrics(mask_metrics)
-                        metrics_mgr.add_metric("time/get_sample_level_mask", get_sample_level_mask_timer.last)
-
-                    # 2. 处理reward相关策略
-                    with Timer(name="reward_postprocess", logger=None) as reward_postprocess_timer:
-                        domain_batch, response_level_metrics = reward_postprocess(
-                            domain_batch, self.pipeline_config, self.running
+                    with Timer(name="cal_old_log_probs_values", logger=None) as cal_old_logpb_timer:
+                        batch.meta_info["is_offload_states"] = False
+                        if self.pipeline_config.adv_estimator == "gae":
+                            values_refs: List[ray.ObjectRef] = self.critic.compute_values(batch, blocking=False)
+                        old_log_probs_refs: List[ray.ObjectRef] = self.actor_train.compute_log_probs(batch, blocking=False)
+                        old_log_probs = DataProto.materialize_concat(data_refs=old_log_probs_refs)
+                        agg_entropy = agg_loss(
+                            loss_mat=old_log_probs.batch["entropy"],
+                            loss_mask=batch.batch["response_mask"][:, 1:],
+                            loss_agg_mode="token-mean",
                         )
-                        metrics_mgr.add_metrics(response_level_metrics)
-                        metrics_mgr.add_metric("time/reward_postprocess", reward_postprocess_timer.last)
+                        batch.meta_info["agg_entropy"] = agg_entropy
 
-                    # 3. 计算token level rewards
-                    with Timer(name="get_token_reward", logger=None) as get_token_reward_timer:
-                        domain_batch, token_level_metrics = compute_token_reward(
-                            domain_batch, self.pipeline_config, self.kl_ctrl
-                        )
-                        metrics_mgr.add_metrics(token_level_metrics)
-                        metrics_mgr.add_metric("time/get_token_reward", get_token_reward_timer.last)
+                        if self.pipeline_config.adv_estimator == "gae":
+                            values = DataProto.materialize_concat(data_refs=values_refs)
+                            batch = batch.union(values)
+                            metrics_mgr.add_reduced_metrics(values.meta_info.pop("metrics", {}))
 
-                    # 4. 计算advantage
-                    final_response_mask = domain_batch.batch["final_response_mask"].clone()
-                    with Timer(name="compute_advantage", logger=None) as compute_advantage_timer:
-                        domain_batch = compute_advantage(
-                            data=domain_batch,
-                            gamma=self.pipeline_config.gamma,
-                            lambd=self.pipeline_config.lambd,
-                            adv_estimator=self.pipeline_config.adv_estimator,
-                            advantage_clip=self.pipeline_config.advantage_clip,
-                            whiten_advantages=self.pipeline_config.whiten_advantages,
-                            whiten_rewards=self.pipeline_config.whiten_rewards,
-                            response_mask=final_response_mask,
-                        )
-                        domain_metrics = reduce_metrics(domain_batch.meta_info.pop("metrics", {}))
-                        metrics_mgr.add_domain_metrics(domain, domain_metrics)
-                        metrics_mgr.add_metric("time/compute_advantage", compute_advantage_timer.last)
-                        batch_list.append(domain_batch)
+                        batch.batch["old_log_probs"] = old_log_probs.batch["log_probs"]
+                        metrics_mgr.add_reduced_metrics(old_log_probs.meta_info.pop("metrics", {}))
+                        metrics_mgr.add_metric("time/old_log_probs", cal_old_logpb_timer.last)
 
-                batch = DataProto.concat(batch_list)
-                batch.reorder(indices=torch.argsort(batch.batch["prompt_id"]))
-                batch.pop("prompt_id")
+                    # 要按domain group by处理reward
+                    batch.batch["prompt_id"] = torch.arange(batch.batch.batch_size[0], device=batch.batch.device)
+                    batch_grouped: Dict[str, DataProto] = batch.group_by("domain")
+                    batch_list = []
+                    for domain, domain_batch in batch_grouped.items():
+                        # 1. 处理mask相关策略， 获取sample level mask
+                        with Timer(name="get_sample_level_mask", logger=None) as get_sample_level_mask_timer:
+                            domain_batch, mask_metrics = get_sample_level_mask(domain_batch, self.pipeline_config)
+                            metrics_mgr.add_metrics(mask_metrics)
+                            metrics_mgr.add_metric("time/get_sample_level_mask", get_sample_level_mask_timer.last)
 
-                metrics_mgr.add_all_metrics(
-                    global_step,
-                    batch,
-                    resource_manager=self.resource_manager,
-                    actor_infer=self.actor_infer,
-                    actor_train=self.actor_train,
-                )
-                batch_grouped: Dict[str, DataProto] = batch.group_by("domain")
-                metrics_mgr.add_domain_all_metrics(global_step, batch_grouped)
-
-                with Timer(name="step_train", logger=None) as step_train_timer:
-                    if self.pipeline_config.adv_estimator == "gae":
-                        critic_train_metrics_refs: List[ray.ObjectRef] = self.critic.train_step(batch, blocking=False)
-
-                    with actor_train_timer:
-                        # implement critic warmup
-                        if self.pipeline_config.critic_warmup <= global_step:
-                            # update actor
-                            actor_train_metrics_refs = self.actor_train.train_step(batch, blocking=False)
-                            actor_train_metrics: DataProto = DataProto.materialize_concat(
-                                data_refs=actor_train_metrics_refs
+                        # 2. 处理reward相关策略
+                        with Timer(name="reward_postprocess", logger=None) as reward_postprocess_timer:
+                            domain_batch, response_level_metrics = reward_postprocess(
+                                domain_batch, self.pipeline_config, self.running
                             )
-                            metrics_mgr.add_reduced_metrics(actor_train_metrics.meta_info.pop("metrics", {}))
+                            metrics_mgr.add_metrics(response_level_metrics)
+                            metrics_mgr.add_metric("time/reward_postprocess", reward_postprocess_timer.last)
 
-                    if self.pipeline_config.adv_estimator == "gae":
-                        critic_train_metrics = DataProto.materialize_concat(data_refs=critic_train_metrics_refs)
-                        metrics_mgr.add_reduced_metrics(critic_train_metrics.meta_info.pop("metrics", {}))
+                        # 3. 计算token level rewards
+                        with Timer(name="get_token_reward", logger=None) as get_token_reward_timer:
+                            domain_batch, token_level_metrics = compute_token_reward(
+                                domain_batch, self.pipeline_config, self.kl_ctrl
+                            )
+                            metrics_mgr.add_metrics(token_level_metrics)
+                            metrics_mgr.add_metric("time/get_token_reward", get_token_reward_timer.last)
 
-                    metrics_mgr.add_metric("time/step_train", step_train_timer.last)
+                        # 4. 计算advantage
+                        final_response_mask = domain_batch.batch["final_response_mask"].clone()
+                        with Timer(name="compute_advantage", logger=None) as compute_advantage_timer:
+                            domain_batch = compute_advantage(
+                                data=domain_batch,
+                                gamma=self.pipeline_config.gamma,
+                                lambd=self.pipeline_config.lambd,
+                                adv_estimator=self.pipeline_config.adv_estimator,
+                                advantage_clip=self.pipeline_config.advantage_clip,
+                                whiten_advantages=self.pipeline_config.whiten_advantages,
+                                whiten_rewards=self.pipeline_config.whiten_rewards,
+                                response_mask=final_response_mask,
+                            )
+                            domain_metrics = reduce_metrics(domain_batch.meta_info.pop("metrics", {}))
+                            metrics_mgr.add_domain_metrics(domain, domain_metrics)
+                            metrics_mgr.add_metric("time/compute_advantage", compute_advantage_timer.last)
+                            batch_list.append(domain_batch)
 
-                tps_timer.push_units_processed(n=torch.sum(batch.batch["attention_mask"]).detach().item())
-                actor_infer_timer.push_units_processed(n=torch.sum(batch.batch["attention_mask"]).detach().item())
-                actor_infer_response_timer.push_units_processed(
-                    n=torch.sum(batch.batch["response_mask"]).detach().item()
-                )
-                actor_train_timer.push_units_processed(n=torch.sum(batch.batch["attention_mask"]).detach().item())
+                    batch = DataProto.concat(batch_list)
+                    batch.reorder(indices=torch.argsort(batch.batch["prompt_id"]))
+                    batch.pop("prompt_id")
 
-                metrics = metrics_mgr.get_metrics()
-                # do ckpt
-                self.state.step = global_step
-                self.state.log_history.append(metrics)
-                for domain, scheduler in self.generate_schedulers.items():
-                    self.state.kv[f"scheduler_state_{domain}"] = ray.get(scheduler.get_scheduler_state.remote())
-
-                self.do_checkpoint(global_step=global_step)
-
-                self.tracker.log(values=metrics, step=global_step)
-
-                if global_step % self.pipeline_config.logging_steps == 0:
-                    if int(os.environ.get("RAY_PROFILING", "0")):
-                        timeline_dir = os.path.join(self.pipeline_config.profiler_output_dir, "timeline")
-                        os.makedirs(timeline_dir, exist_ok=True)
-                        ray.timeline(
-                            filename=os.path.join(timeline_dir, f"timeline-step-{global_step}.json"),
-                        )
-
-                    prompts = self.tokenizer.batch_decode(generate_output.batch["prompts"], skip_special_tokens=True)
-                    responses = self.tokenizer.batch_decode(
-                        generate_output.batch["responses"], skip_special_tokens=True
+                    metrics_mgr.add_all_metrics(
+                        global_step,
+                        batch,
+                        resource_manager=self.resource_manager,
+                        actor_infer=self.actor_infer,
+                        actor_train=self.actor_train,
                     )
-                    generate_examples = [{"prompt": p, "response": r} for p, r in zip(prompts, responses)][:10]
-                    logger.info(json.dumps(generate_examples, ensure_ascii=False))
-                    logger.info(json.dumps(metrics, ensure_ascii=False))
+                    batch_grouped: Dict[str, DataProto] = batch.group_by("domain")
+                    metrics_mgr.add_domain_all_metrics(global_step, batch_grouped)
 
-                #### Training done!!
-                if self.shared_storage is not None:
-                    self.shared_storage.set("running_train_job", "empty")
+                    with Timer(name="step_train", logger=None) as step_train_timer:
+                        if self.pipeline_config.adv_estimator == "gae":
+                            critic_train_metrics_refs: List[ray.ObjectRef] = self.critic.train_step(batch, blocking=False)
+
+                        with actor_train_timer:
+                            # implement critic warmup
+                            if self.pipeline_config.critic_warmup <= global_step:
+                                # update actor
+                                actor_train_metrics_refs = self.actor_train.train_step(batch, blocking=False)
+                                actor_train_metrics: DataProto = DataProto.materialize_concat(
+                                    data_refs=actor_train_metrics_refs
+                                )
+                                metrics_mgr.add_reduced_metrics(actor_train_metrics.meta_info.pop("metrics", {}))
+
+                        if self.pipeline_config.adv_estimator == "gae":
+                            critic_train_metrics = DataProto.materialize_concat(data_refs=critic_train_metrics_refs)
+                            metrics_mgr.add_reduced_metrics(critic_train_metrics.meta_info.pop("metrics", {}))
+
+                        metrics_mgr.add_metric("time/step_train", step_train_timer.last)
+
+                    tps_timer.push_units_processed(n=torch.sum(batch.batch["attention_mask"]).detach().item())
+                    actor_infer_timer.push_units_processed(n=torch.sum(batch.batch["attention_mask"]).detach().item())
+                    actor_infer_response_timer.push_units_processed(
+                        n=torch.sum(batch.batch["response_mask"]).detach().item()
+                    )
+                    actor_train_timer.push_units_processed(n=torch.sum(batch.batch["attention_mask"]).detach().item())
+
+                    metrics = metrics_mgr.get_metrics()
+                    # do ckpt
+                    self.state.step = global_step
+                    self.state.log_history.append(metrics)
+                    for domain, scheduler in self.generate_schedulers.items():
+                        self.state.kv[f"scheduler_state_{domain}"] = ray.get(scheduler.get_scheduler_state.remote())
+
+                    self.do_checkpoint(global_step=global_step)
+
+                    self.tracker.log(values=metrics, step=global_step)
+
+                    if global_step % self.pipeline_config.logging_steps == 0:
+                        if int(os.environ.get("RAY_PROFILING", "0")):
+                            timeline_dir = os.path.join(self.pipeline_config.profiler_output_dir, "timeline")
+                            os.makedirs(timeline_dir, exist_ok=True)
+                            ray.timeline(
+                                filename=os.path.join(timeline_dir, f"timeline-step-{global_step}.json"),
+                            )
+
+                        prompts = self.tokenizer.batch_decode(generate_output.batch["prompts"], skip_special_tokens=True)
+                        responses = self.tokenizer.batch_decode(
+                            generate_output.batch["responses"], skip_special_tokens=True
+                        )
+                        generate_examples = [{"prompt": p, "response": r} for p, r in zip(prompts, responses)][:10]
+                        logger.info(json.dumps(generate_examples, ensure_ascii=False))
+                        logger.info(json.dumps(metrics, ensure_ascii=False))
 
                 logger.info(f"pipeline step {global_step} finished")
                 global_step += 1

--- a/roll/pipeline/rlvr/rlvr_pipeline.py
+++ b/roll/pipeline/rlvr/rlvr_pipeline.py
@@ -36,6 +36,7 @@ from roll.utils.functionals import (
 from roll.utils.kl_controller import get_kl_controller
 from roll.utils.logging import get_logger
 from roll.utils.metrics.metrics_manager import MetricsManager
+from roll.utils.gpu_mem_monitor import GPUMemoryMonitor
 
 logger = get_logger()
 
@@ -243,7 +244,7 @@ class RLVRPipeline(BasePipeline):
                     node_id=ray.get_runtime_context().get_node_id(),
                     soft=False,
                 )
-            ).remote(pipeline_config=self.pipeline_config)
+            ).remote(pipeline_config=self.pipeline_config, job_name=self.job_name)
             ray.get(
                 generate_scheduler.set_scheduler.remote(
                     actor_cluster=self.actor_infer,
@@ -266,12 +267,13 @@ class RLVRPipeline(BasePipeline):
         if self.val_dataset:
             val_pipeline_config = copy.deepcopy(self.pipeline_config)
             val_pipeline_config.use_additional_prompts = False
+            val_pipeline_config.enable_migration = False
             self.val_generate_scheduler = DynamicSamplingScheduler.options(
                 scheduling_strategy=NodeAffinitySchedulingStrategy(
                     node_id=ray.get_runtime_context().get_node_id(),
                     soft=False,
                 )
-            ).remote(pipeline_config=val_pipeline_config)
+            ).remote(pipeline_config=val_pipeline_config, job_name=self.job_name)
         if self.val_dataset:
             ray.get(
                 self.val_generate_scheduler.set_scheduler.remote(
@@ -337,7 +339,7 @@ class RLVRPipeline(BasePipeline):
 
             metrics_mgr.clear_metrics()
             with tps_timer, Timer(name="step_total", logger=None) as step_total_timer:
-                with self.scheduler_section("update"):
+                with self.scheduler_section("update"), GPUMemoryMonitor(interval_sec=0.02) as gmonitor:
                     # 先model update，resume时不需要保存infer cluster的状态
                     if self.pipeline_config.adv_estimator == "gae":
                         self.critic.offload_states(blocking=True)
@@ -348,12 +350,6 @@ class RLVRPipeline(BasePipeline):
                         metrics_mgr.add_metrics(model_update_metrics)
                         metrics_mgr.add_metric("time/step_model_update", step_model_update_timer.last)
 
-                    # TODO: this validation pass should be enabled, but should not be here, maybe move it to generate section.
-                    # if self.val_dataset and global_step % self.pipeline_config.eval_steps == 0:
-                    #     with Timer(name="val_step", logger=None) as val_step_timer:
-                    #         val_metrics = self.val()
-                    #         metrics_mgr.add_metrics(val_metrics)
-                    #         metrics_mgr.add_metric("time/val_step", val_step_timer.last)
                 batch: DataProto = DataProto()
                 batch.meta_info = {"global_step": global_step}
 
@@ -367,6 +363,12 @@ class RLVRPipeline(BasePipeline):
                         self.actor_infer.start_server(data=DataProto(meta_info=batch.meta_info))
                         for reward_cluster in self.rewards.values():
                             reward_cluster.load_states()
+
+                        if self.val_dataset and global_step % self.pipeline_config.eval_steps == 0:
+                            with Timer(name="val_step", logger=None) as val_step_timer:
+                                val_metrics = self.val(init=False)
+                                metrics_mgr.add_metrics(val_metrics)
+                                metrics_mgr.add_metric("time/val_step", val_step_timer.last)
 
                         batch.meta_info["is_offload_states"] = False
                         scheduler_refs = {}
@@ -537,25 +539,27 @@ class RLVRPipeline(BasePipeline):
         logger.info("pipeline complete!")
 
     @torch.no_grad()
-    def val(self):
+    def val(self, init: bool = False):
         val_metrics_mgr = MetricsManager()
         batch = DataProto()
 
         with Timer(name="step_generate", logger=None) as step_generate_timer:
             batch.meta_info["is_offload_states"] = False
             batch.meta_info["generation_config"] = self.pipeline_config.validation.generating_args.to_dict()
-
-            self.actor_infer.start_server(data=DataProto(meta_info=batch.meta_info))
-            for reward_cluster in self.rewards.values():
-                reward_cluster.load_states()
+            # As we invoke val() inside the generate phase, initialization should be skipped
+            if init:
+                self.actor_infer.start_server(data=DataProto(meta_info=batch.meta_info))
+                for reward_cluster in self.rewards.values():
+                    reward_cluster.load_states()
             generate_output: DataProto = ray.get(
                 self.val_generate_scheduler.get_batch.remote(data=batch, batch_size=len(self.val_dataset)),
                 timeout=self.pipeline_config.rpc_timeout
             )
-            self.actor_infer.stop_server()
             generate_output.meta_info.pop("is_offload_states", None)
-            for reward_cluster in self.rewards.values():
-                reward_cluster.offload_states()
+            if init:
+                self.actor_infer.stop_server()
+                for reward_cluster in self.rewards.values():
+                    reward_cluster.offload_states()
             val_metrics_mgr.add_metric("time/step_generate", step_generate_timer.last)
 
         batch = generate_output

--- a/roll/utils/gpu_mem_monitor.py
+++ b/roll/utils/gpu_mem_monitor.py
@@ -1,0 +1,56 @@
+import time
+from contextlib import ContextDecorator
+import pynvml
+
+
+class GPUMemoryMonitor(ContextDecorator):
+    """
+    Context manager monitors all GPU's memory usage on this node
+    """
+    def __init__(self, interval_sec: float = None, print_fn=print):
+        """
+        :param interval_sec: interval of gpu memory usage sampling
+        :param print_fn: logging function used to print output
+        """
+        self.interval_sec = interval_sec
+        self.print_fn = print_fn
+        self._running = False
+        pynvml
+
+    def __enter__(self):
+        pynvml.nvmlInit()
+        self.device_count = pynvml.nvmlDeviceGetCount()
+        self.print_fn(f"[GPUMonitor] Total #GPUs: {self.device_count}")
+
+        self.print_fn("[GPUMonitor] On enter: ")
+        self._log_memory()
+
+        if self.interval_sec and self.interval_sec > 0:
+            self._running = True
+            import threading
+            self.thread = threading.Thread(target=self._loop_monitor, daemon=True)
+            self.thread.start()
+
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._running = False
+        if hasattr(self, "thread"):
+            self.thread.join(timeout=1)
+        self.print_fn("[GPUMonitor] On exit: ")
+        self._log_memory()
+        pynvml.nvmlShutdown()
+
+    def _log_memory(self):
+        for i in range(self.device_count):
+            handle = pynvml.nvmlDeviceGetHandleByIndex(i)
+            mem_info = pynvml.nvmlDeviceGetMemoryInfo(handle)
+            used_mb = mem_info.used / 1024**2
+            total_mb = mem_info.total / 1024**2
+            self.print_fn(f"  GPU {i}: {used_mb:.1f} MB / {total_mb:.1f} MB")
+
+    def _loop_monitor(self):
+        while self._running:
+            self.print_fn("[GPUMonitor] GPU memory used: ")
+            self._log_memory()
+            time.sleep(self.interval_sec)

--- a/start_rlvr_superpod.sh
+++ b/start_rlvr_superpod.sh
@@ -1,1 +1,1 @@
-VLLM_USE_V1=0 PYTHONPATH=. python examples/start_rlvr_pipeline.py --config_path qwen2.5-7B-rlvr_megatron --config_name new_rlvr_config_8gpu
+VLLM_USE_V1=0 PYTHONPATH=. python examples/start_rlvr_pipeline.py --config_path qwen2.5-7B-rlvr_megatron --config_name new_rlvr_config_4gpu

--- a/worker_scheduler/resource_manager.py
+++ b/worker_scheduler/resource_manager.py
@@ -91,6 +91,7 @@ class ResourceManager:
                 self.train_resource_mapping[j] = job_name
             self.train_available_devices.sort()
             assert self.job_mapping[job_name].allocated_gpus == [], f"Non-empty allocated_gpus before train: {self.job_mapping[job_name].allocated_gpus}"
+            self.job_mapping[job_name].allocated_gpus = gpus_to_allocate.copy()
             return gpus_to_allocate
         return None
 

--- a/worker_scheduler/resource_manager.py
+++ b/worker_scheduler/resource_manager.py
@@ -10,72 +10,119 @@ class JobStatus:
     max_gen_gpus: int
     max_train_gpus: int
     # For a running generation phase, 1 <= |allocated_gpus| <= max_gen_gpus
-    # For a running generation phase, |allocated_gpus| = max_train_gpus
+    # For a running train phase, |allocated_gpus| = max_train_gpus
     allocated_gpus: List[int]
 
 
 class ResourceManager:
-    def __init__(self, gen_device_mapping: List[int]) -> None:
-        self.available_devices = sorted(gen_device_mapping.copy())
-        self.resource_mapping: Dict[int, str] = {i: None for i in gen_device_mapping}
+    def __init__(self, gen_device_ids: List[int], train_device_ids: List[int]) -> None:
+        self.gen_available_devices = sorted(gen_device_ids.copy())
+        self.train_available_devices = sorted(train_device_ids.copy())
+        self.gen_resource_mapping: Dict[int, str] = {i: None for i in gen_device_ids}
+        self.train_resource_mapping: Dict[int, str] = {i: None for i in train_device_ids}
         # job_mapping: job_name -> JobStatus
         self.job_mapping: Dict[str, JobStatus] = {}
-        self.cluster_size = len(self.available_devices)
+        self.gen_cluster_size = len(self.gen_available_devices)
+        self.train_cluster_size = len(self.train_available_devices)
+
+    @property
+    def num_available_devices(self):
+        return len(self.gen_available_devices) + len(self.train_available_devices)
+
+    @property
+    def cluster_size(self):
+        return self.gen_cluster_size + self.train_cluster_size
 
     def release(self, job_name: str, gpu_list: List[int]):
         '''Release the given GPU list'''
-        assert len(set(gpu_list).intersection(self.available_devices)) == 0
-        self.available_devices += gpu_list
-        self.available_devices.sort()
+        assert len(set(gpu_list).intersection(self.train_available_devices)) == 0
+        assert len(set(gpu_list).intersection(self.gen_available_devices)) == 0
         for i in gpu_list:
-            self.resource_mapping[i] = None
+            if i in self.train_resource_mapping:
+                self.train_resource_mapping[i] = None
+                self.train_available_devices.append(i)
+            elif i in self.gen_resource_mapping:
+                self.gen_resource_mapping[i] = None
+                self.gen_available_devices.append(i)
+            else:
+                assert False, f"Try to release GPU: {i}, which is not in train/gen pool"
             self.job_mapping[job_name].allocated_gpus.remove(i)
+        self.train_available_devices.sort()
+        self.gen_available_devices.sort()
 
     def register_job(self, init_job_status: JobStatus):
-        assert init_job_status.max_gen_gpus <= self.cluster_size
-        assert init_job_status.max_train_gpus <= self.cluster_size
+        assert init_job_status.max_gen_gpus <= self.gen_cluster_size
+        assert init_job_status.max_train_gpus <= self.train_cluster_size
         self.job_mapping[init_job_status.job_name] = init_job_status
 
     def update_phase(self, job_name: str, new_phase: Phase):
         self.job_mapping[job_name].phase = new_phase
 
-    def allocate_worker(self, job_name: str) -> Optional[List]:
+    def allocate_worker(self, job_name: str, pool: str) -> Optional[List]:
         '''Allocate `gpus_per_worker` GPUs to job_name'''
-        gpus_per_worker = self.job_mapping[job_name].gpus_per_gen_worker
-        assert self.cluster_size % gpus_per_worker == 0
-        for i in range(0, self.cluster_size, gpus_per_worker):
-            can_allocate = True
-            for j in range(i, i + gpus_per_worker):
-                if j not in self.available_devices:
-                    can_allocate = False
-            if can_allocate:
+        assert pool in ['train', 'gen'], f"Resource pool can only be train or gen, got {pool}"
+        if pool == 'gen':
+            gpus_per_worker = self.job_mapping[job_name].gpus_per_gen_worker
+            assert self.gen_cluster_size % gpus_per_worker == 0
+            start_gen_gid = min(self.gen_resource_mapping.keys())
+            for i in range(start_gen_gid, start_gen_gid + self.gen_cluster_size, gpus_per_worker):
+                can_allocate = True
                 for j in range(i, i + gpus_per_worker):
-                    self.available_devices.remove(j)
-                    assert self.resource_mapping[j] is None
-                    self.resource_mapping[j] = job_name
-                self.job_mapping[job_name].allocated_gpus += list(range(i, i + gpus_per_worker))
-                return list(range(i, i + gpus_per_worker))
+                    if j not in self.gen_available_devices:
+                        can_allocate = False
+                if can_allocate:
+                    for j in range(i, i + gpus_per_worker):
+                        self.gen_available_devices.remove(j)
+                        assert self.gen_resource_mapping[j] is None
+                        self.gen_resource_mapping[j] = job_name
+                    self.job_mapping[job_name].allocated_gpus += list(range(i, i + gpus_per_worker))
+                    return list(range(i, i + gpus_per_worker))
+        else:
+            # For train allocation request, we allocate max_train_gpus for it at once
+            num_train_gpus = self.job_mapping[job_name].max_train_gpus
+            free_gpus = [i for i in self.train_resource_mapping.keys() if self.train_resource_mapping[i] is None]
+            assert len(free_gpus) == len(self.train_available_devices)
+            if len(free_gpus) < num_train_gpus:
+                return None
+            gpus_to_allocate = free_gpus[:num_train_gpus].copy()
+            for j in gpus_to_allocate:
+                self.train_available_devices.remove(j)
+                assert self.train_resource_mapping[j] is None
+                self.train_resource_mapping[j] = job_name
+            self.train_available_devices.sort()
+            assert self.job_mapping[job_name].allocated_gpus == [], f"Non-empty allocated_gpus before train: {self.job_mapping[job_name].allocated_gpus}"
+            return gpus_to_allocate
         return None
 
     def cleanup_by_name(self, job_name: str) -> int:
         '''Returns the released GPU count'''
         cleanup_count = 0
-        for i in self.resource_mapping:
-            if self.resource_mapping[i] == job_name:
-                assert i not in self.available_devices
-                self.resource_mapping[i] = None
-                self.available_devices.append(i)
+        for i in self.gen_resource_mapping:
+            if self.gen_resource_mapping[i] == job_name:
+                assert i not in self.gen_available_devices
+                self.gen_resource_mapping[i] = None
+                self.gen_available_devices.append(i)
+                cleanup_count += 1
+        for i in self.train_resource_mapping:
+            if self.train_resource_mapping[i] == job_name:
+                assert i not in self.train_available_devices
+                self.train_resource_mapping[i] = None
+                self.train_available_devices.append(i)
                 cleanup_count += 1
         self.job_mapping[job_name].allocated_gpus = []
-        self.available_devices.sort()
+        self.gen_available_devices.sort()
+        self.train_available_devices.sort()
         return cleanup_count
 
     def allocate_all(self, job_name: str) -> None:
         '''Allocate all GPUs to job_name'''
-        for i in self.resource_mapping:
-            self.resource_mapping[i] = job_name
-        self.job_mapping[job_name].allocated_gpus = self.available_devices.copy()
-        self.available_devices = []
+        for i in self.gen_resource_mapping:
+            self.gen_resource_mapping[i] = job_name
+        for i in self.train_resource_mapping:
+            self.train_resource_mapping[i] = job_name
+        self.job_mapping[job_name].allocated_gpus = self.gen_available_devices.copy() + self.train_available_devices.copy()
+        self.gen_available_devices = []
+        self.train_available_devices = []
 
     def get_running_jobs(self):
         '''Get all running job names'''

--- a/worker_scheduler/scheduler.py
+++ b/worker_scheduler/scheduler.py
@@ -48,7 +48,7 @@ class FCFSPolicy:
         assert event_to_run.event_type == EventType.READY
         if event_to_run.level == EventLevel.JOB:
             # If there are enough resource to schedule an init now
-            if len(resource_manager.available_devices) == resource_manager.cluster_size:
+            if resource_manager.num_available_devices == resource_manager.cluster_size:
                 resource_manager.register_job(
                     get_init_job_status(event_to_run.job_name, self.shared_storage)
                 )
@@ -60,8 +60,8 @@ class FCFSPolicy:
         elif event_to_run.phase == Phase.GENERATE:
             assert event_to_run.level == EventLevel.PHASE
             job_status = resource_manager.job_mapping[event_to_run.job_name]
-            print(f"[Policy] available_devices: {resource_manager.available_devices}, {job_status.max_gen_gpus}, {self.min_concurrency_ratio}")
-            if len(resource_manager.available_devices) / job_status.max_gen_gpus >= self.min_concurrency_ratio:
+            print(f"[Policy] available_devices: (gen){resource_manager.gen_available_devices} (train){resource_manager.train_available_devices}, {job_status.max_gen_gpus}, {self.min_concurrency_ratio}")
+            if len(resource_manager.gen_available_devices) / job_status.max_gen_gpus >= self.min_concurrency_ratio:
                 event_queue.pop(0)
                 events_to_execute = []
                 events_to_execute.append(
@@ -71,8 +71,9 @@ class FCFSPolicy:
                         value='running'
                     )
                 )
-                for i in range(len(resource_manager.available_devices) // job_status.gpus_per_gen_worker):
-                    resource_manager.allocate_worker(event_to_run.job_name)
+                for i in range(len(resource_manager.gen_available_devices) // job_status.gpus_per_gen_worker):
+                    workers = resource_manager.allocate_worker(event_to_run.job_name, 'gen')
+                    print(f"Alloc worker: {workers}")
                     events_to_execute.append(
                         Event(event_to_run.job_name,
                             EventType.STATUS,
@@ -86,16 +87,19 @@ class FCFSPolicy:
                 return None
         elif event_to_run.phase == Phase.TRAIN:
             job_status = resource_manager.job_mapping[event_to_run.job_name]
-            if len(resource_manager.available_devices) >= job_status.max_train_gpus:
+            if len(resource_manager.train_available_devices) >= job_status.max_train_gpus:
                 event_queue.pop(0)
+                resource_manager.allocate_worker(event_to_run.job_name, 'train')
                 return [Event(event_to_run.job_name, EventType.STATUS, phase=Phase.TRAIN, value='running')]
             else:
                 return None
         elif event_to_run.phase == Phase.UPDATE:
             job_status = resource_manager.job_mapping[event_to_run.job_name]
-            # TODO: fix gpu count here
-            if len(resource_manager.available_devices) >= job_status.max_train_gpus:
+            # TODO: fix gpu count here, now only update if all GPUs are free
+            # Update should not acquire all GPUs at the same time.
+            if resource_manager.num_available_devices == resource_manager.cluster_size:
                 event_queue.pop(0)
+                resource_manager.allocate_all(event_to_run.job_name)
                 return [Event(event_to_run.job_name, EventType.STATUS, phase=Phase.UPDATE, value='running')]
             else:
                 return None
@@ -109,7 +113,7 @@ class Scheduler:
         self.msg_channel = self.shared_storage.pubsub()
         self.msg_channel.subscribe("tenant_events")
         self.msg_channel.listen()
-        self.resource_manager = ResourceManager([0, 1, 2, 3])
+        self.resource_manager = ResourceManager(gen_device_ids=[2, 3], train_device_ids=[0, 1])
         self.ready_queue = []
         self.lock = threading.Lock()
         self.select_policy = policy
@@ -141,11 +145,19 @@ class Scheduler:
                 return
             elif event.level == EventLevel.PHASE:
                 # if init done or update done, then next step's generation is ready to run
-                if event.phase == Phase.INIT or event.phase == Phase.UPDATE:
+                if event.phase == Phase.INIT:
+                    ready_event = Event(
+                        job_name=event.job_name,
+                        event_type=EventType.READY,
+                        phase=Phase.UPDATE)
+                    self.ready_queue.append(ready_event)
+                # if update done, then free all its resources next step's generation is ready to run
+                elif event.phase == Phase.UPDATE:
                     ready_event = Event(
                         job_name=event.job_name,
                         event_type=EventType.READY,
                         phase=Phase.GENERATE)
+                    self.resource_manager.cleanup_by_name(event.job_name)
                     self.ready_queue.append(ready_event)
                 # if generate done, then its training is ready to begin
                 elif event.phase == Phase.GENERATE:
@@ -154,12 +166,13 @@ class Scheduler:
                         event_type=EventType.READY,
                         phase=Phase.TRAIN)
                     self.ready_queue.append(ready_event)
-                # if training done, then its parameter update is ready to begin
+                # if training done, then free its train resources and its parameter update is ready to begin
                 elif event.phase == Phase.TRAIN:
                     ready_event = Event(
                         job_name=event.job_name,
                         event_type=EventType.READY,
                         phase=Phase.UPDATE)
+                    self.resource_manager.cleanup_by_name(event.job_name)
                     self.ready_queue.append(ready_event)
                 else:
                     assert False, f"Unexpected finish event: {event}"
@@ -184,6 +197,7 @@ class Scheduler:
                 logging.info("Listen thread: exiting...")
                 break
             event: Event = EventParser.parse(data)
+            print(f"[Router] event: {event}, available_devices_before: (gen){self.resource_manager.gen_available_devices} (train){self.resource_manager.train_available_devices},")
             with self.lock:
                 self.backend_router.handle_event(event)  
 


### PR DESCRIPTION
Now, multi-tenant scheduler + full RLVR pipeline (w/ training and update) is functional.

TODOs:
1)  `update` function currently requires both train and generate workers to be active (see `scheduler.py`, L98), which should be changed.
2) I have tested it for ~20 steps using Qwen 0.5B, but did not find an increasing score/mean, maybe try more steps
